### PR TITLE
trigger rebuild of 0.1.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: True  # [py<35]
-  number: 2
+  number: 3
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
windows builds keep failing with rllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='repo.continuum.io', port=443): Read timeout